### PR TITLE
Included a tag parameter in the NeekoPlayerWidget

### DIFF
--- a/lib/src/neeko_fullscreen_player.dart
+++ b/lib/src/neeko_fullscreen_player.dart
@@ -39,7 +39,8 @@ Widget fullScreenRoutePageBuilder(
     Duration startAt,
     Function onSkipPrevious,
     Function onSkipNext,
-    NeekoPlayerOptions playerOptions}) {
+    NeekoPlayerOptions playerOptions,
+    String tag}) {
   return _FullscreenPlayer(
     videoControllerWrapper: videoControllerWrapper,
     aspectRatio: aspectRatio,
@@ -53,6 +54,7 @@ Widget fullScreenRoutePageBuilder(
     playerOptions: playerOptions,
     onSkipPrevious: onSkipPrevious,
     onSkipNext: onSkipNext,
+    tag: "com.jarvanmo.neekoPlayerHeroTag",
   );
 }
 //
@@ -110,6 +112,8 @@ class _FullscreenPlayer extends StatefulWidget {
   final Color progressBarHandleColor;
   final Color progressBarBackgroundColor;
 
+  final String tag;
+
   const _FullscreenPlayer(
       {Key key,
       this.videoControllerWrapper,
@@ -128,7 +132,8 @@ class _FullscreenPlayer extends StatefulWidget {
       this.progressBarPlayedColor,
       this.progressBarBufferedColor,
       this.progressBarHandleColor,
-      this.progressBarBackgroundColor})
+      this.progressBarBackgroundColor,
+      this.tag})
       : super(key: key);
 
   @override
@@ -200,7 +205,7 @@ class __FullscreenPlayerState extends State<_FullscreenPlayer> {
       child: SafeArea(
         child: Center(
           child: Hero(
-            tag: "com.jarvanmo.neekoPlayerHeroTag",
+            tag: this.widget.tag,
             child: Container(
               width: widget.width ?? MediaQuery.of(context).size.width,
               child: AspectRatio(

--- a/lib/src/neeko_player_widget.dart
+++ b/lib/src/neeko_player_widget.dart
@@ -70,6 +70,9 @@ class NeekoPlayerWidget extends StatefulWidget {
   final Color progressBarHandleColor;
   final Color progressBarBackgroundColor;
 
+  /// Allow developers to indicate a custom tag (which is linked with its corresponding fullscreen)
+  final String tag;
+
   NeekoPlayerWidget(
       {Key key,
       @required this.videoControllerWrapper,
@@ -88,7 +91,8 @@ class NeekoPlayerWidget extends StatefulWidget {
       this.progressBarPlayedColor,
       this.progressBarBufferedColor: const Color(0xFF757575),
       this.progressBarHandleColor,
-      this.progressBarBackgroundColor: const Color(0xFFF5F5F5)})
+      this.progressBarBackgroundColor: const Color(0xFFF5F5F5),
+      this.tag: "com.jarvanmo.neekoPlayerHeroTag"})
       : assert(videoControllerWrapper != null),
         assert(playerOptions != null),
         super(key: key);
@@ -247,7 +251,7 @@ class _NeekoPlayerWidgetState extends State<NeekoPlayerWidget> {
 //    }
 
     return Hero(
-      tag: "com.jarvanmo.neekoPlayerHeroTag",
+      tag: this.widget.tag,
       child: Container(
         width: widget.width ?? MediaQuery.of(context).size.width,
         child: AspectRatio(


### PR DESCRIPTION
The inclusion of the tag parameter in the NeekoPlayerWidget allow the developers to include several players in same screen, without conflicts in the fullscreen hero tag.